### PR TITLE
Version v0.0.3 update

### DIFF
--- a/cmd/capi/capi.go
+++ b/cmd/capi/capi.go
@@ -49,11 +49,15 @@ var CNIurl string = "https://docs.projectcalico.org/v3.20/manifests/calico.yaml"
 var decUnstructured = yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 
 // CreateAwsK8sInstance creates a Kubernetes cluster on AWS using CAPI and CAPI-AWS
-func CreateAwsK8sInstance(kindkconfig string, clusterName *string, workdir string, awscreds map[string]string, capicfg string) (bool, error) {
+func CreateAwsK8sInstance(kindkconfig string, clusterName *string, workdir string, awscreds map[string]string, capicfg string, createHaCluster bool) (bool, error) {
 	// Export AWS settings as Env vars
 	for k := range awscreds {
 		os.Setenv(k, awscreds[k])
 	}
+
+	// Set up variables
+	var cpMachineCount int64
+	var workerMachineCount int64
 
 	// Boostrapping Cloud Formation stack on AWS
 	log.Info("Boostrapping Cloud Formation stack on AWS")
@@ -116,8 +120,16 @@ func CreateAwsK8sInstance(kindkconfig string, clusterName *string, workdir strin
 
 	//	Set up options to write out the install YAML
 	//	TODO: Make Kubernetes version an option
-	var cpMachineCount int64 = 3
-	var workerMachineCount int64 = 3
+	if createHaCluster {
+		// If HA was requested we create it
+		cpMachineCount = 3
+		workerMachineCount = 3
+		//
+	} else {
+		// If HA was NOT requested we create a small cluster
+		cpMachineCount = 1
+		workerMachineCount = 2
+	}
 	cto := capiclient.GetClusterTemplateOptions{
 		Kubeconfig:               capiclient.Kubeconfig{Path: kindkconfig},
 		ClusterName:              *clusterName,
@@ -212,7 +224,7 @@ func CreateAwsK8sInstance(kindkconfig string, clusterName *string, workdir strin
 	}
 
 	//	Then, wait for the CP to appear
-	_, err = waitForCP(clusterInstallConfig, *clusterName)
+	_, err = waitForCP(clusterInstallConfig, *clusterName, createHaCluster)
 	if err != nil {
 		return false, err
 	}
@@ -296,8 +308,10 @@ func CreateAwsK8sInstance(kindkconfig string, clusterName *string, workdir strin
 }
 
 // CreateDevelK8sInstance creates a K8S cluster on Docker
-func CreateDevelK8sInstance(kindkconfig string, clusterName *string, workdir string, capicfg string) (bool, error) {
+func CreateDevelK8sInstance(kindkconfig string, clusterName *string, workdir string, capicfg string, createHaCluster bool) (bool, error) {
 	log.Info("Initializing Docker provider")
+	var cpMachineCount int64
+	var workerMachineCount int64
 
 	c, err := capiclient.New("")
 	if err != nil {
@@ -322,8 +336,16 @@ func CreateDevelK8sInstance(kindkconfig string, clusterName *string, workdir str
 
 	//	Set up options to write out the install YAML
 	//	TODO: Make Kubernetes version an option
-	var cpMachineCount int64 = 3
-	var workerMachineCount int64 = 3
+	if createHaCluster {
+		// If HA was requested we create it
+		cpMachineCount = 3
+		workerMachineCount = 3
+		//
+	} else {
+		// If HA was NOT requested we create a small cluster
+		cpMachineCount = 1
+		workerMachineCount = 2
+	}
 	cto := capiclient.GetClusterTemplateOptions{
 		Kubeconfig:               capiclient.Kubeconfig{Path: kindkconfig},
 		ClusterName:              *clusterName,
@@ -420,7 +442,7 @@ func CreateDevelK8sInstance(kindkconfig string, clusterName *string, workdir str
 	}
 
 	//	Then, wait for the CP to appear
-	_, err = waitForCP(clusterInstallConfig, *clusterName)
+	_, err = waitForCP(clusterInstallConfig, *clusterName, createHaCluster)
 	if err != nil {
 		return false, err
 	}
@@ -617,11 +639,18 @@ func waitForAWSInfra(restConfig *rest.Config, clustername string) (bool, error) 
 
 // waitForCP waits until the CP to come up
 //	TODO: probably should use https://pkg.go.dev/k8s.io/client-go/tools/watch
-func waitForCP(restConfig *rest.Config, clustername string) (bool, error) {
+func waitForCP(restConfig *rest.Config, clustername string, createHaCluster bool) (bool, error) {
 	log.Info("Waiting for the Control Plane to appear")
 	// Set the vars we need
 	cpname := clustername + "-control-plane"
-	var expectedCPReplicas int32 = 3
+	var expectedCPReplicas int32
+
+	if createHaCluster {
+		expectedCPReplicas = 3
+	} else {
+		expectedCPReplicas = 1
+
+	}
 
 	// We need to load the scheme since it's not part of the core API
 	scheme := runtime.NewScheme()

--- a/cmd/createCluster.go
+++ b/cmd/createCluster.go
@@ -3,15 +3,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/christianh814/gokp/cmd/argo"
-	"github.com/christianh814/gokp/cmd/capi"
-	"github.com/christianh814/gokp/cmd/export"
-
-	"github.com/christianh814/gokp/cmd/github"
-	"github.com/christianh814/gokp/cmd/kind"
-	"github.com/christianh814/gokp/cmd/templates"
-	"github.com/christianh814/gokp/cmd/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -20,183 +11,33 @@ var createClusterCmd = &cobra.Command{
 	Use:     "create-cluster",
 	Aliases: []string{"createCluster"},
 	Short:   "Create a GitOps Ready K8S Cluster",
-	Long: `Create a GitOps Ready K8S Cluster using CAPI + Argo CD!
-
-Currenly only AWS + GitHub works.
+	Long: `Create a GitOps Ready K8S Cluster using CAPI!
 
 This is a PoC stage (proof of concept) and should NOT
 be used for production. There will be lots of breaking changes
 so beware. There be dragons here. PRE-PRE-ALPHA`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// create home dir
-		err := os.MkdirAll(os.Getenv("HOME")+"/.gokp", 0775)
-		if err != nil {
-			log.Fatal(err)
+		// Show help if a subcommand isn't supplied
+		if len(args) == 0 {
+			cmd.Help()
+			os.Exit(0)
 		}
-		// Create workdir and set variables based on that
-		WorkDir, _ = utils.CreateWorkDir()
-		KindCfg = WorkDir + "/" + "kind.kubeconfig"
-		// cleanup workdir at the end
-		defer os.RemoveAll(WorkDir)
-
-		// Grab repo related flags
-		ghToken, _ := cmd.Flags().GetString("github-token")
-		clusterName, _ := cmd.Flags().GetString("cluster-name")
-		privateRepo, _ := cmd.Flags().GetBool("private-repo")
-
-		// Grab AWS related flags
-		awsRegion, _ := cmd.Flags().GetString("aws-region")
-		awsAccessKey, _ := cmd.Flags().GetString("aws-access-key")
-		awsSecretKey, _ := cmd.Flags().GetString("aws-secret-key")
-		awsSSHKey, _ := cmd.Flags().GetString("aws-ssh-key")
-		awsCPMachine, _ := cmd.Flags().GetString("aws-control-plane-machine")
-		awsWMachine, _ := cmd.Flags().GetString("aws-node-machine")
-		skipCloudFormation, _ := cmd.Flags().GetBool("skip-cloud-formation")
-
-		CapiCfg := WorkDir + "/" + clusterName + ".kubeconfig"
-		gokpartifacts := os.Getenv("HOME") + "/.gokp/" + clusterName
-
-		tcpName := "gokp-bootstrapper"
-
-		// Run PreReq Checks
-		_, err = utils.CheckPreReqs(gokpartifacts)
-		if err != nil {
-			log.Fatal(err)
+		whatToRun := args[0]
+		switch {
+		case whatToRun != "help":
+			cmd.Help()
+		case whatToRun != "aws":
+			cmd.Help()
+			os.Exit(0)
+		case whatToRun != "development":
+			cmd.Help()
+			os.Exit(0)
 		}
-
-		// Create KIND instance
-		log.Info("Creating temporary control plane")
-		err = kind.CreateKindCluster(tcpName, KindCfg)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Create CAPI instance on AWS
-		awsCredsMap := map[string]string{
-			"AWS_REGION":                     awsRegion,
-			"AWS_ACCESS_KEY_ID":              awsAccessKey,
-			"AWS_SECRET_ACCESS_KEY":          awsSecretKey,
-			"AWS_SSH_KEY_NAME":               awsSSHKey,
-			"AWS_CONTROL_PLANE_MACHINE_TYPE": awsCPMachine,
-			"AWS_NODE_MACHINE_TYPE":          awsWMachine,
-		}
-
-		// By default, create an HA Cluster
-		haCluster := true
-		_, err = capi.CreateAwsK8sInstance(KindCfg, &clusterName, WorkDir, awsCredsMap, CapiCfg, haCluster, skipCloudFormation)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Create the GitOps repo
-		_, gitopsrepo, err := github.CreateRepo(&clusterName, ghToken, &privateRepo, WorkDir)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Create repo dir structure. Including Argo CD install YAMLs and base YAMLs. Push initial dir structure out
-		_, err = templates.CreateRepoSkel(&clusterName, WorkDir, ghToken, gitopsrepo, &privateRepo)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Export/Create Cluster YAML to the Repo, Make sure kustomize is used for the core components
-		log.Info("Exporting Cluster YAML")
-		_, err = export.ExportClusterYaml(CapiCfg, WorkDir+"/"+clusterName)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Git push newly exported YAML to GitOps repo
-		_, err = github.CommitAndPush(WorkDir+"/"+clusterName, ghToken, "exporting existing YAML")
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Install Argo CD on the newly created cluster
-		// Deploy applications/applicationsets
-		log.Info("Deploying Argo CD GitOps Controller")
-		_, err = argo.BootstrapArgoCD(&clusterName, WorkDir, CapiCfg)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// MOVE from kind to capi instance
-		//	uses the kubeconfig files of "src ~> dest"
-		log.Info("Moving CAPI Artifacts to: " + clusterName)
-		_, err = capi.MoveMgmtCluster(KindCfg, CapiCfg)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Delete local Kind Cluster
-		log.Info("Deleting temporary control plane")
-		err = kind.DeleteKindCluster(tcpName, KindCfg)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Move components to ~/.gokp/<clustername> and remove stuff you don't need to know.
-		// 	TODO: this is ugly and will refactor this later
-		///err = utils.CopyDir(WorkDir, gokpartifacts)
-		err = os.Rename(WorkDir, gokpartifacts)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		notNeededDirs := []string{
-			"argocd-install-output",
-			"capi-install-yamls-output",
-			"cni-output",
-		}
-
-		for _, notNeededDir := range notNeededDirs {
-			err = os.RemoveAll(gokpartifacts + "/" + notNeededDir)
-			if err != nil {
-				log.Fatal(err)
-			}
-		}
-
-		notNeededFiles := []string{
-			"argocd-install.yaml",
-			"cni.yaml",
-			"install-cluster.yaml",
-			"kind.kubeconfig",
-		}
-
-		for _, notNeededFile := range notNeededFiles {
-			err = os.Remove(gokpartifacts + "/" + notNeededFile)
-			if err != nil {
-				log.Fatal(err)
-			}
-		}
-
-		// Give info
-		log.Info("Cluster Successfully installed! Everything you need is under: ~/.gokp/", clusterName)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(createClusterCmd)
-	// Repo specific flags
-	createClusterCmd.Flags().String("github-token", "", "GitHub token to use.")
-	createClusterCmd.Flags().String("cluster-name", "", "Name of your cluster.")
-	createClusterCmd.Flags().BoolP("private-repo", "", true, "Create a private repo.")
-
-	//AWS Specific flags
-	createClusterCmd.Flags().String("aws-region", "us-east-1", "Which region to deploy to.")
-	createClusterCmd.Flags().String("aws-access-key", "", "Your AWS Access Key.")
-	createClusterCmd.Flags().String("aws-secret-key", "", "Your AWS Secret Key.")
-	createClusterCmd.Flags().String("aws-ssh-key", "default", "The SSH key in AWS that you want to use for the instances.")
-	createClusterCmd.Flags().String("aws-control-plane-machine", "m4.xlarge", "The AWS instance type for the Control Plane")
-	createClusterCmd.Flags().String("aws-node-machine", "m4.xlarge", "The AWS instance type for the Worker instances")
-	createClusterCmd.Flags().BoolP("skip-cloud-formation", "", false, "Skip the creation of the CloudFormation Template.")
-
-	// require the following flags
-	createClusterCmd.MarkFlagRequired("github-token")
-	createClusterCmd.MarkFlagRequired("cluster-name")
-	createClusterCmd.MarkFlagRequired("aws-access-key")
-	createClusterCmd.MarkFlagRequired("aws-secret-key")
 
 	// Here you will define your flags and configuration settings.
 

--- a/cmd/createCluster.go
+++ b/cmd/createCluster.go
@@ -80,7 +80,9 @@ so beware. There be dragons here. PRE-PRE-ALPHA`,
 			"AWS_NODE_MACHINE_TYPE":          awsWMachine,
 		}
 
-		_, err = capi.CreateAwsK8sInstance(KindCfg, &clusterName, WorkDir, awsCredsMap, CapiCfg)
+		// By default, create an HA Cluster
+		haCluster := true
+		_, err = capi.CreateAwsK8sInstance(KindCfg, &clusterName, WorkDir, awsCredsMap, CapiCfg, haCluster)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/createCluster.go
+++ b/cmd/createCluster.go
@@ -51,6 +51,7 @@ so beware. There be dragons here. PRE-PRE-ALPHA`,
 		awsSSHKey, _ := cmd.Flags().GetString("aws-ssh-key")
 		awsCPMachine, _ := cmd.Flags().GetString("aws-control-plane-machine")
 		awsWMachine, _ := cmd.Flags().GetString("aws-node-machine")
+		skipCloudFormation, _ := cmd.Flags().GetBool("skip-cloud-formation")
 
 		CapiCfg := WorkDir + "/" + clusterName + ".kubeconfig"
 		gokpartifacts := os.Getenv("HOME") + "/.gokp/" + clusterName
@@ -82,7 +83,7 @@ so beware. There be dragons here. PRE-PRE-ALPHA`,
 
 		// By default, create an HA Cluster
 		haCluster := true
-		_, err = capi.CreateAwsK8sInstance(KindCfg, &clusterName, WorkDir, awsCredsMap, CapiCfg, haCluster)
+		_, err = capi.CreateAwsK8sInstance(KindCfg, &clusterName, WorkDir, awsCredsMap, CapiCfg, haCluster, skipCloudFormation)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -189,6 +190,7 @@ func init() {
 	createClusterCmd.Flags().String("aws-ssh-key", "default", "The SSH key in AWS that you want to use for the instances.")
 	createClusterCmd.Flags().String("aws-control-plane-machine", "m4.xlarge", "The AWS instance type for the Control Plane")
 	createClusterCmd.Flags().String("aws-node-machine", "m4.xlarge", "The AWS instance type for the Worker instances")
+	createClusterCmd.Flags().BoolP("skip-cloud-formation", "", false, "Skip the creation of the CloudFormation Template.")
 
 	// require the following flags
 	createClusterCmd.MarkFlagRequired("github-token")

--- a/cmd/createCluster.go
+++ b/cmd/createCluster.go
@@ -38,14 +38,4 @@ so beware. There be dragons here. PRE-PRE-ALPHA`,
 
 func init() {
 	rootCmd.AddCommand(createClusterCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// createClusterCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// createClusterCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/createCluster_aws.go
+++ b/cmd/createCluster_aws.go
@@ -1,0 +1,51 @@
+/*
+Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// awsCmd represents the aws command
+var awsCmd = &cobra.Command{
+	Use:   "aws",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("aws called")
+	},
+}
+
+func init() {
+	createClusterCmd.AddCommand(awsCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// awsCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// awsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/createCluster_aws.go
+++ b/cmd/createCluster_aws.go
@@ -15,8 +15,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// awsCmd represents the aws command
-var awsCmd = &cobra.Command{
+// awscreateCmd represents the aws create command
+var awscreateCmd = &cobra.Command{
 	Use:   "aws",
 	Short: "Creates a GOKP Cluster on AWS",
 	Long: `Create a GOKP Cluster on AWS. This will build a cluster on AWS using the given
@@ -182,35 +182,25 @@ doesn't create one for you).`,
 }
 
 func init() {
-	createClusterCmd.AddCommand(awsCmd)
+	createClusterCmd.AddCommand(awscreateCmd)
 
 	// Repo specific flags
-	awsCmd.Flags().String("github-token", "", "GitHub token to use.")
-	awsCmd.Flags().String("cluster-name", "", "Name of your cluster.")
-	awsCmd.Flags().BoolP("private-repo", "", true, "Create a private repo.")
+	awscreateCmd.Flags().String("github-token", "", "GitHub token to use.")
+	awscreateCmd.Flags().String("cluster-name", "", "Name of your cluster.")
+	awscreateCmd.Flags().BoolP("private-repo", "", true, "Create a private repo.")
 
 	//AWS Specific flags
-	awsCmd.Flags().String("aws-region", "us-east-1", "Which region to deploy to.")
-	awsCmd.Flags().String("aws-access-key", "", "Your AWS Access Key.")
-	awsCmd.Flags().String("aws-secret-key", "", "Your AWS Secret Key.")
-	awsCmd.Flags().String("aws-ssh-key", "default", "The SSH key in AWS that you want to use for the instances.")
-	awsCmd.Flags().String("aws-control-plane-machine", "m4.xlarge", "The AWS instance type for the Control Plane")
-	awsCmd.Flags().String("aws-node-machine", "m4.xlarge", "The AWS instance type for the Worker instances")
-	awsCmd.Flags().BoolP("skip-cloud-formation", "", false, "Skip the creation of the CloudFormation Template.")
+	awscreateCmd.Flags().String("aws-region", "us-east-1", "Which region to deploy to.")
+	awscreateCmd.Flags().String("aws-access-key", "", "Your AWS Access Key.")
+	awscreateCmd.Flags().String("aws-secret-key", "", "Your AWS Secret Key.")
+	awscreateCmd.Flags().String("aws-ssh-key", "default", "The SSH key in AWS that you want to use for the instances.")
+	awscreateCmd.Flags().String("aws-control-plane-machine", "m4.xlarge", "The AWS instance type for the Control Plane")
+	awscreateCmd.Flags().String("aws-node-machine", "m4.xlarge", "The AWS instance type for the Worker instances")
+	awscreateCmd.Flags().BoolP("skip-cloud-formation", "", false, "Skip the creation of the CloudFormation Template.")
 
 	// require the following flags
-	awsCmd.MarkFlagRequired("github-token")
-	awsCmd.MarkFlagRequired("cluster-name")
-	awsCmd.MarkFlagRequired("aws-access-key")
-	awsCmd.MarkFlagRequired("aws-secret-key")
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// awsCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// awsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	awscreateCmd.MarkFlagRequired("github-token")
+	awscreateCmd.MarkFlagRequired("cluster-name")
+	awscreateCmd.MarkFlagRequired("aws-access-key")
+	awscreateCmd.MarkFlagRequired("aws-secret-key")
 }

--- a/cmd/createCluster_aws.go
+++ b/cmd/createCluster_aws.go
@@ -1,43 +1,208 @@
-/*
-Copyright © 2021 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package cmd
 
 import (
-	"fmt"
+	"os"
 
+	"github.com/christianh814/gokp/cmd/argo"
+	"github.com/christianh814/gokp/cmd/capi"
+	"github.com/christianh814/gokp/cmd/export"
+
+	"github.com/christianh814/gokp/cmd/github"
+	"github.com/christianh814/gokp/cmd/kind"
+	"github.com/christianh814/gokp/cmd/templates"
+	"github.com/christianh814/gokp/cmd/utils"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 // awsCmd represents the aws command
 var awsCmd = &cobra.Command{
 	Use:   "aws",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+	Short: "Creates a GOKP Cluster on AWS",
+	Long: `Create a GOKP Cluster on AWS. This will build a cluster on AWS using the given
+credentials. For example:
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+gokp create-cluster --cluster-name=mycluster \
+--github-token=githubtoken \
+--aws-ssh-key=sshkeynameonaws \
+--aws-access-key=awsaccesskeyid \
+--aws-secret-key=awssecretaccesskey \
+--private-repo=true
+
+The aws ssh key must already exist on your account (the installer
+doesn't create one for you).`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("aws called")
+		// create home dir
+		err := os.MkdirAll(os.Getenv("HOME")+"/.gokp", 0775)
+		if err != nil {
+			log.Fatal(err)
+		}
+		// Create workdir and set variables based on that
+		WorkDir, _ = utils.CreateWorkDir()
+		KindCfg = WorkDir + "/" + "kind.kubeconfig"
+		// cleanup workdir at the end
+		defer os.RemoveAll(WorkDir)
+
+		// Grab repo related flags
+		ghToken, _ := cmd.Flags().GetString("github-token")
+		clusterName, _ := cmd.Flags().GetString("cluster-name")
+		privateRepo, _ := cmd.Flags().GetBool("private-repo")
+
+		// Grab AWS related flags
+		awsRegion, _ := cmd.Flags().GetString("aws-region")
+		awsAccessKey, _ := cmd.Flags().GetString("aws-access-key")
+		awsSecretKey, _ := cmd.Flags().GetString("aws-secret-key")
+		awsSSHKey, _ := cmd.Flags().GetString("aws-ssh-key")
+		awsCPMachine, _ := cmd.Flags().GetString("aws-control-plane-machine")
+		awsWMachine, _ := cmd.Flags().GetString("aws-node-machine")
+		skipCloudFormation, _ := cmd.Flags().GetBool("skip-cloud-formation")
+
+		CapiCfg := WorkDir + "/" + clusterName + ".kubeconfig"
+		gokpartifacts := os.Getenv("HOME") + "/.gokp/" + clusterName
+
+		tcpName := "gokp-bootstrapper"
+
+		// Run PreReq Checks
+		_, err = utils.CheckPreReqs(gokpartifacts)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Create KIND instance
+		log.Info("Creating temporary control plane")
+		err = kind.CreateKindCluster(tcpName, KindCfg)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Create CAPI instance on AWS
+		awsCredsMap := map[string]string{
+			"AWS_REGION":                     awsRegion,
+			"AWS_ACCESS_KEY_ID":              awsAccessKey,
+			"AWS_SECRET_ACCESS_KEY":          awsSecretKey,
+			"AWS_SSH_KEY_NAME":               awsSSHKey,
+			"AWS_CONTROL_PLANE_MACHINE_TYPE": awsCPMachine,
+			"AWS_NODE_MACHINE_TYPE":          awsWMachine,
+		}
+
+		// By default, create an HA Cluster
+		haCluster := true
+		_, err = capi.CreateAwsK8sInstance(KindCfg, &clusterName, WorkDir, awsCredsMap, CapiCfg, haCluster, skipCloudFormation)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Create the GitOps repo
+		_, gitopsrepo, err := github.CreateRepo(&clusterName, ghToken, &privateRepo, WorkDir)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Create repo dir structure. Including Argo CD install YAMLs and base YAMLs. Push initial dir structure out
+		_, err = templates.CreateRepoSkel(&clusterName, WorkDir, ghToken, gitopsrepo, &privateRepo)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Export/Create Cluster YAML to the Repo, Make sure kustomize is used for the core components
+		log.Info("Exporting Cluster YAML")
+		_, err = export.ExportClusterYaml(CapiCfg, WorkDir+"/"+clusterName)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Git push newly exported YAML to GitOps repo
+		_, err = github.CommitAndPush(WorkDir+"/"+clusterName, ghToken, "exporting existing YAML")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Install Argo CD on the newly created cluster
+		// Deploy applications/applicationsets
+		log.Info("Deploying Argo CD GitOps Controller")
+		_, err = argo.BootstrapArgoCD(&clusterName, WorkDir, CapiCfg)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// MOVE from kind to capi instance
+		//	uses the kubeconfig files of "src ~> dest"
+		log.Info("Moving CAPI Artifacts to: " + clusterName)
+		_, err = capi.MoveMgmtCluster(KindCfg, CapiCfg)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Delete local Kind Cluster
+		log.Info("Deleting temporary control plane")
+		err = kind.DeleteKindCluster(tcpName, KindCfg)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Move components to ~/.gokp/<clustername> and remove stuff you don't need to know.
+		// 	TODO: this is ugly and will refactor this later
+		///err = utils.CopyDir(WorkDir, gokpartifacts)
+		err = os.Rename(WorkDir, gokpartifacts)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		notNeededDirs := []string{
+			"argocd-install-output",
+			"capi-install-yamls-output",
+			"cni-output",
+		}
+
+		for _, notNeededDir := range notNeededDirs {
+			err = os.RemoveAll(gokpartifacts + "/" + notNeededDir)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		notNeededFiles := []string{
+			"argocd-install.yaml",
+			"cni.yaml",
+			"install-cluster.yaml",
+			"kind.kubeconfig",
+		}
+
+		for _, notNeededFile := range notNeededFiles {
+			err = os.Remove(gokpartifacts + "/" + notNeededFile)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		// Give info
+		log.Info("Cluster Successfully installed! Everything you need is under: ~/.gokp/", clusterName)
+
 	},
 }
 
 func init() {
 	createClusterCmd.AddCommand(awsCmd)
+
+	// Repo specific flags
+	awsCmd.Flags().String("github-token", "", "GitHub token to use.")
+	awsCmd.Flags().String("cluster-name", "", "Name of your cluster.")
+	awsCmd.Flags().BoolP("private-repo", "", true, "Create a private repo.")
+
+	//AWS Specific flags
+	awsCmd.Flags().String("aws-region", "us-east-1", "Which region to deploy to.")
+	awsCmd.Flags().String("aws-access-key", "", "Your AWS Access Key.")
+	awsCmd.Flags().String("aws-secret-key", "", "Your AWS Secret Key.")
+	awsCmd.Flags().String("aws-ssh-key", "default", "The SSH key in AWS that you want to use for the instances.")
+	awsCmd.Flags().String("aws-control-plane-machine", "m4.xlarge", "The AWS instance type for the Control Plane")
+	awsCmd.Flags().String("aws-node-machine", "m4.xlarge", "The AWS instance type for the Worker instances")
+	awsCmd.Flags().BoolP("skip-cloud-formation", "", false, "Skip the creation of the CloudFormation Template.")
+
+	// require the following flags
+	awsCmd.MarkFlagRequired("github-token")
+	awsCmd.MarkFlagRequired("cluster-name")
+	awsCmd.MarkFlagRequired("aws-access-key")
+	awsCmd.MarkFlagRequired("aws-secret-key")
 
 	// Here you will define your flags and configuration settings.
 

--- a/cmd/createCluster_development.go
+++ b/cmd/createCluster_development.go
@@ -16,10 +16,9 @@ import (
 
 // developmentClusterCmd represents the developmentCluster command
 var developmentClusterCmd = &cobra.Command{
-	Use:     "development-cluster",
-	Aliases: []string{"developmentCluster"},
-	Short:   "Creates a local testing cluster using Docker",
-	Long: `Create a GitOps Ready K8S Test Cluster using CAPI + Argo CD!
+	Use:   "development",
+	Short: "Creates a local testing cluster using Docker",
+	Long: `Create a GitOps Ready K8S Test Cluster using CAPI!
 
 Currenly Docker + GitHub.
 	
@@ -154,7 +153,7 @@ so beware. This create a local cluster for testing. PRE-PRE-ALPHA.`,
 }
 
 func init() {
-	rootCmd.AddCommand(developmentClusterCmd)
+	createClusterCmd.AddCommand(developmentClusterCmd)
 
 	// Repo Specific Flags
 	developmentClusterCmd.Flags().String("github-token", "", "GitHub token to use.")
@@ -165,14 +164,4 @@ func init() {
 	// required flags
 	developmentClusterCmd.MarkFlagRequired("github-token")
 	developmentClusterCmd.MarkFlagRequired("cluster-name")
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// developmentClusterCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// developmentClusterCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/deleteCluster.go
+++ b/cmd/deleteCluster.go
@@ -3,11 +3,6 @@ package cmd
 import (
 	"os"
 
-	log "github.com/sirupsen/logrus"
-
-	"github.com/christianh814/gokp/cmd/capi"
-	"github.com/christianh814/gokp/cmd/kind"
-	"github.com/christianh814/gokp/cmd/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -19,71 +14,26 @@ var deleteClusterCmd = &cobra.Command{
 	Long: `This will delete your cluster based on the kubeconfig file
 and name you pass it. This only deletes the cluster and not the git repo.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Create workdir and set variables
-		WorkDir, _ = utils.CreateWorkDir()
-		KindCfg = WorkDir + "/" + "kind.kubeconfig"
-		tcpName := "gokp-bootstrapper"
-
-		// cleanup workdir at the end
-		defer os.RemoveAll(WorkDir)
-
-		// Grab flags
-		clusterName, _ := cmd.Flags().GetString("cluster-name")
-		CapiCfg, _ := cmd.Flags().GetString("kubeconfig")
-
-		// Create KIND cluster
-		log.Info("Creating temporary control plane")
-		err := kind.CreateKindCluster(tcpName, KindCfg)
-		if err != nil {
-			log.Fatal(err)
+		// Show help if a subcommand isn't supplied
+		if len(args) == 0 {
+			cmd.Help()
+			os.Exit(0)
 		}
-
-		// Move Capi components to the KIND cluster
-		log.Info("Moving CAPI Artifacts to the tempoary control plane")
-		_, err = capi.MoveMgmtCluster(CapiCfg, KindCfg)
-		if err != nil {
-			log.Fatal(err)
-
+		whatToRun := args[0]
+		switch {
+		case whatToRun != "help":
+			cmd.Help()
+		case whatToRun != "aws":
+			cmd.Help()
+			os.Exit(0)
+		case whatToRun != "development":
+			cmd.Help()
+			os.Exit(0)
 		}
-
-		// Delete cluster
-		log.Info("Deleteing cluster: " + clusterName)
-		_, err = capi.DeleteCluster(KindCfg, clusterName)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Delete local Kind Cluster
-		log.Info("Deleting temporary control plane")
-		err = kind.DeleteKindCluster(tcpName, KindCfg)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// If we're here, the cluster should be deleted
-		log.Info("Cluster " + clusterName + " successfully deleted")
 
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(deleteClusterCmd)
-
-	// Define flags for delete-cluster
-	deleteClusterCmd.Flags().String("kubeconfig", "", "Path to the Kubeconfig file of the gokp cluster")
-	deleteClusterCmd.Flags().String("cluster-name", "", "Name of the gokp cluster.")
-
-	// all flags required
-	deleteClusterCmd.MarkFlagRequired("kubeconfig")
-	deleteClusterCmd.MarkFlagRequired("cluster-name")
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// deleteClusterCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// deleteClusterCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/deleteCluster_aws.go
+++ b/cmd/deleteCluster_aws.go
@@ -1,0 +1,51 @@
+/*
+Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// awsCmd represents the aws command
+var awsCmd = &cobra.Command{
+	Use:   "aws",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("aws called")
+	},
+}
+
+func init() {
+	deleteClusterCmd.AddCommand(awsCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// awsCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// awsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/deleteCluster_development.go
+++ b/cmd/deleteCluster_development.go
@@ -11,9 +11,8 @@ import (
 
 // developmentDeleteCmd represents the developmentDelete command
 var developmentDeleteCmd = &cobra.Command{
-	Use:     "development-delete",
-	Aliases: []string{"developmentDelete"},
-	Short:   "Deletes the gokp development cluster",
+	Use:   "development",
+	Short: "Deletes the gokp development cluster",
 	Long: `This will delete your development cluster based on the kubeconfig file
 and name you pass it. This only deletes the local development cluster and not the git repo.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -38,7 +37,7 @@ and name you pass it. This only deletes the local development cluster and not th
 }
 
 func init() {
-	rootCmd.AddCommand(developmentDeleteCmd)
+	deleteClusterCmd.AddCommand(developmentDeleteCmd)
 
 	// Define flags for delete-cluster
 	developmentDeleteCmd.Flags().String("kubeconfig", "", "Path to the Kubeconfig file of the gokp cluster")
@@ -47,13 +46,4 @@ func init() {
 	// all flags required
 	developmentDeleteCmd.MarkFlagRequired("kubeconfig")
 	developmentDeleteCmd.MarkFlagRequired("cluster-name")
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// developmentDeleteCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// developmentDeleteCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/developmentCluster.go
+++ b/cmd/developmentCluster.go
@@ -43,6 +43,9 @@ so beware. This create a local cluster for testing. PRE-PRE-ALPHA.`,
 		clusterName, _ := cmd.Flags().GetString("cluster-name")
 		privateRepo, _ := cmd.Flags().GetBool("private-repo")
 
+		// HA request
+		createHaCluster, _ := cmd.Flags().GetBool("ha")
+
 		// Set up cluster artifacts
 		CapiCfg := WorkDir + "/" + clusterName + ".kubeconfig"
 		gokpartifacts := os.Getenv("HOME") + "/.gokp/" + clusterName
@@ -64,7 +67,7 @@ so beware. This create a local cluster for testing. PRE-PRE-ALPHA.`,
 		}
 
 		// Create Development instance
-		_, err = capi.CreateDevelK8sInstance(KindCfg, &clusterName, WorkDir, CapiCfg)
+		_, err = capi.CreateDevelK8sInstance(KindCfg, &clusterName, WorkDir, CapiCfg, createHaCluster)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -157,6 +160,7 @@ func init() {
 	developmentClusterCmd.Flags().String("github-token", "", "GitHub token to use.")
 	developmentClusterCmd.Flags().String("cluster-name", "", "Name of your cluster.")
 	developmentClusterCmd.Flags().BoolP("private-repo", "", true, "Create a private repo.")
+	developmentClusterCmd.Flags().BoolP("ha", "", false, "Create an HA cluster.")
 
 	// required flags
 	developmentClusterCmd.MarkFlagRequired("github-token")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,7 @@ var CapiCfg string
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:     "gokp",
-	Version: "v0.0.2",
+	Version: "v0.0.3",
 	Short:   "GOKP installs a GitOps ready Kubernetes cluster",
 	Long: `GOKP creates a Kubernetes cluster using CAPI. It is
 meant to be a GitOps native Kubernetes cluster ready to use.


### PR DESCRIPTION
This update

* Development cluster now only deploys 1 master and 2 nodes. Has an optional "emulate HA" mode.
* Adds `--skip-cloud-formation`  option for those who ran the CloudFormation already (fixes #8)
* Label Workers of the clusters as such (was previously unlabeled)
* Making create-cluster and delete-cluster provider agnostic. This also removed the need to have a separate development-create and development-delete subcomands. (fixes #3)